### PR TITLE
Disalbe Java SSLv2 handshakes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ COPY . /sigidoc
 WORKDIR /sigidoc
 
 RUN apk --no-cache add bash
+RUN sed -i 's/SSLv3/&, SSLv2/' /opt/java/openjdk/jre/lib/security/java.security
 
 CMD ["./build.sh"]


### PR DESCRIPTION
This Pull Request adds a `sed` command to the `Dockerfile` which adds `SSLv2` to the list of `jdk.tls.disabledAlgorithms` within the file `/opt/java/openjdk/jre/lib/security/java.security`. This should solve a problem where GitHub could not successfully connect to the Webhooks endpoint.